### PR TITLE
Fix navigation imports and session navigation helper

### DIFF
--- a/ai/ai.py
+++ b/ai/ai.py
@@ -1,6 +1,6 @@
 from typing import List, Tuple
 import streamlit as st
-from common.ui import topbar, go, stable_key_tuple
+from common.ui import topbar, get_go, stable_key_tuple
 
 AI_CSS = """
 <style>
@@ -49,6 +49,7 @@ def _class(is_removed: bool) -> str:
     return "dp-card red" if is_removed else "dp-card green"
 
 def page_ai_select():
+    go = get_go()
     SUBJECTS = st.session_state["_SUBJECTS"]
     MODS     = st.session_state["_MODS"]
     IQS      = st.session_state["_IQS"]
@@ -74,6 +75,7 @@ def page_ai_select():
         go("ai_review")
 
 def page_ai_review():
+    go = get_go()
     topbar("Review suggested dotpoints", back_to="ai_select")
     st.markdown(AI_CSS, unsafe_allow_html=True)
     st.write("Toggle each card to Kept (green) or Removed (red). Tally updates live. Apply to add kept items.")

--- a/common/ui.py
+++ b/common/ui.py
@@ -15,18 +15,26 @@ def safe_rerun():
     else:
         raise RuntimeError("No rerun method available in this Streamlit version.")
 
-def set_go():
+def set_go(go=None):
     """
-    Inject a 'go' function into session_state for navigation.
-    Usage: st.session_state['_go']("route_name")
+    Inject a 'go' function into ``st.session_state`` for navigation.
+
+    If ``go`` is ``None`` a default implementation is created which sets the
+    ``route`` entry in ``session_state`` and triggers a rerun.  The function
+    stored in ``session_state['_go']`` is returned.
     """
-    def go(route: str):
-        st.session_state["route"] = route
-        safe_rerun()
+    if go is None:
+        def go(route: str):
+            st.session_state["route"] = route
+            safe_rerun()
 
     # Put it in session_state for global access
     st.session_state["_go"] = go
     return go
+
+def get_go():
+    """Helper to retrieve the navigation function from session state."""
+    return st.session_state.get("_go")
 
 # ------------------------------
 # UI helpers
@@ -65,3 +73,7 @@ def k_iq_toggle(subject: str, module: str, iq: str, prefix: str) -> str:
 
 def k_dp_toggle(subject: str, module: str, iq: str, dp: str, prefix: str) -> str:
     return f"{prefix}_dp_toggle_{subject}_{module}_{iq}_{dp}"
+
+def stable_key_tuple(item: tuple[str, ...]) -> str:
+    """Create a stable string key from a tuple of strings."""
+    return "|".join(item)

--- a/cram/cram.py
+++ b/cram/cram.py
@@ -1,39 +1,14 @@
 import streamlit as st
-from common.ui import topbar, go
-from selection.widgets import subject_cards, module_cards, iq_cards, dotpoint_cards
-
-def page_cram_subjects():
-    subject_cards(
-        key_prefix="cram",
-        back_to=("srs_menu" if st.session_state["cram_mode"] else "select_subject_main")
-    )
-    mid = st.columns([1,1,1])[1]
-    with mid:
-        if st.button("Review selected dotpoints", type="primary", use_container_width=True):
-            go("cram_review")
-
-def page_cram_modules():
-    s = st.session_state.get("focus_subject")
-    if not s: go("cram_subjects"); return
-    module_cards(s, key_prefix="cram", back_to="cram_subjects")
-
-def page_cram_iqs():
-    sm = st.session_state.get("focus_module")
-    if not sm: go("cram_modules"); return
-    s, m = sm
-    iq_cards(s, m, key_prefix="cram", back_to="cram_modules")
-
-def page_cram_dotpoints():
-    smi = st.session_state.get("focus_iq")
-    if not smi: go("cram_iqs"); return
-    s, m, iq = smi
-    dotpoint_cards(s, m, iq, key_prefix="cram", back_to="cram_iqs")
-    mid = st.columns([1,1,1])[1]
-    with mid:
-        if st.button("Review selected dotpoints", type="primary", use_container_width=True):
-            go("cram_review")
+from common.ui import topbar, get_go
+from selection.widgets import (
+    page_cram_subjects,
+    page_cram_modules,
+    page_cram_iqs,
+    page_cram_dotpoints,
+)
 
 def page_cram_how():
+    go = get_go()
     topbar("How to review", back_to="cram_review")
     mode = st.radio("Choose order:", ["SR order (spaced repetition)", "Prioritization (based on strengths/weaknesses)"])
     if mode.startswith("Prioritization"):

--- a/homepage/homepage.py
+++ b/homepage/homepage.py
@@ -1,7 +1,8 @@
 import streamlit as st
-from common.ui import go
+from common.ui import get_go
 
 def page_home():
+    go = get_go()
     st.title("Syllabuddy")
     st.write("Stay on track with spaced repetition, prioritised cramming, and targeted practice.")
     c1, c2 = st.columns(2, gap="large")
@@ -13,6 +14,7 @@ def page_home():
             go("select_subject_main")
 
 def page_select_subject_main():
+    go = get_go()
     from common.ui import topbar
     topbar("Select Subject", back_to="home")
     st.write("Choose subjects/modules/IQs/dotpoints or try AI-based selection.")

--- a/review/review.py
+++ b/review/review.py
@@ -1,6 +1,6 @@
 from typing import List, Tuple
 import streamlit as st
-from common.ui import topbar, go, stable_key_tuple
+from common.ui import topbar, get_go, stable_key_tuple
 
 # Removed set stored deterministically (no random keys)
 def _get_removed(route_key: str) -> set[str]:
@@ -100,6 +100,7 @@ def review_box(
     back_to: str,
     after_submit_route: str,
 ):
+    go = get_go()
     topbar(title, back_to=back_to)
     st.markdown(REVIEW_CSS, unsafe_allow_html=True)
 

--- a/selection/widgets.py
+++ b/selection/widgets.py
@@ -1,6 +1,6 @@
 import streamlit as st
 from common.ui import (
-    topbar, go,
+    topbar, get_go,
     k_subject_open, k_subject_toggle,
     k_module_open,  k_module_toggle,
     k_iq_open,      k_iq_toggle,
@@ -55,6 +55,7 @@ def is_iq_selected(subject: str, module: str, iq: str) -> bool:
 # =============================
 
 def page_cram_subjects():
+    go = get_go()
     SUBJECTS = st.session_state["_SUBJECTS"]
     topbar("Choose Subject", back_to="srs_menu")
     st.caption("Open drills down. “Select” toggles all children (modules → IQs → dotpoints).")
@@ -94,6 +95,7 @@ def page_cram_subjects():
         st.button("Review selected dotpoints", type="primary", use_container_width=True, on_click=go, args=("cram_review",))
 
 def page_cram_modules():
+    go = get_go()
     MODS = st.session_state["_MODS"]
     s = st.session_state.get("focus_subject")
     if not s:
@@ -134,6 +136,7 @@ def page_cram_modules():
         st.button("Review selected dotpoints", type="primary", use_container_width=True, on_click=go, args=("cram_review",))
 
 def page_cram_iqs():
+    go = get_go()
     IQS = st.session_state["_IQS"]
     sm = st.session_state.get("focus_module")
     if not sm:
@@ -175,6 +178,7 @@ def page_cram_iqs():
         st.button("Review selected dotpoints", type="primary", use_container_width=True, on_click=go, args=("cram_review",))
 
 def page_cram_dotpoints():
+    go = get_go()
     DPS = st.session_state["_DPS"]
     smi = st.session_state.get("focus_iq")
     if not smi:
@@ -215,6 +219,7 @@ def page_cram_dotpoints():
 # =============================
 
 def page_srs_subjects():
+    go = get_go()
     SUBJECTS = st.session_state["_SUBJECTS"]
     topbar("Choose Subject", back_to="srs_menu")
     st.caption("Open drills down. “Select” toggles all children (modules → IQs → dotpoints).")
@@ -251,6 +256,7 @@ def page_srs_subjects():
         st.button("Review selected dotpoints", type="primary", use_container_width=True, on_click=go, args=("srs_review",))
 
 def page_srs_modules():
+    go = get_go()
     MODS = st.session_state["_MODS"]
     s = st.session_state.get("focus_subject")
     if not s:
@@ -291,6 +297,7 @@ def page_srs_modules():
         st.button("Review selected dotpoints", type="primary", use_container_width=True, on_click=go, args=("srs_review",))
 
 def page_srs_iqs():
+    go = get_go()
     IQS = st.session_state["_IQS"]
     sm = st.session_state.get("focus_module")
     if not sm:
@@ -332,6 +339,7 @@ def page_srs_iqs():
         st.button("Review selected dotpoints", type="primary", use_container_width=True, on_click=go, args=("srs_review",))
 
 def page_srs_dotpoints():
+    go = get_go()
     DPS = st.session_state["_DPS"]
     smi = st.session_state.get("focus_iq")
     if not smi:

--- a/srs/srs.py
+++ b/srs/srs.py
@@ -1,8 +1,14 @@
 import streamlit as st
-from common.ui import topbar, go
-from selection.widgets import subject_cards, module_cards, iq_cards, dotpoint_cards
+from common.ui import topbar, get_go
+from selection.widgets import (
+    page_srs_subjects,
+    page_srs_modules,
+    page_srs_iqs,
+    page_srs_dotpoints,
+)
 
 def page_srs_menu():
+    go = get_go()
     topbar("Spaced Repetition", back_to="home")
     due_count = max(1, len(st.session_state["sel_dotpoints"]))
     st.write(f"**All (Today):** {due_count} dotpoints due")
@@ -19,31 +25,3 @@ def page_srs_menu():
             st.session_state["cram_mode"] = True
             st.session_state["prioritization_mode"] = False
             go("cram_subjects")
-
-def page_srs_subjects():
-    subject_cards(key_prefix="srs", back_to="srs_menu")
-    mid = st.columns([1,1,1])[1]
-    with mid:
-        if st.button("Review selected dotpoints", type="primary", use_container_width=True):
-            go("srs_review")
-
-def page_srs_modules():
-    s = st.session_state.get("focus_subject")
-    if not s: go("srs_subjects"); return
-    module_cards(s, key_prefix="srs", back_to="srs_subjects")
-
-def page_srs_iqs():
-    sm = st.session_state.get("focus_module")
-    if not sm: go("srs_modules"); return
-    s, m = sm
-    iq_cards(s, m, key_prefix="srs", back_to="srs_modules")
-
-def page_srs_dotpoints():
-    smi = st.session_state.get("focus_iq")
-    if not smi: go("srs_iqs"); return
-    s, m, iq = smi
-    dotpoint_cards(s, m, iq, key_prefix="srs", back_to="srs_iqs")
-    mid = st.columns([1,1,1])[1]
-    with mid:
-        if st.button("Review selected dotpoints", type="primary", use_container_width=True):
-            go("srs_review")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -4,11 +4,13 @@ from data.data import load_syllabus, explode_syllabus, ensure_core_state
 from common.style import inject_css
 from common.ui import set_go, safe_rerun
 
-# Initialize navigation
-if "_go" not in st.session_state:
-    go = set_go()
-else:
-    go = st.session_state["_go"]
+# ---------- router setter that works across Streamlit versions ----------
+def go(route: str):
+    st.session_state["route"] = route
+    safe_rerun()
+
+# register go() for submodules
+set_go(go)
 
 # Pages
 from homepage.homepage import page_home, page_select_subject_main
@@ -26,14 +28,6 @@ from review.review import page_srs_review, page_cram_review
 # ---------- page config & CSS ----------
 st.set_page_config(page_title="Syllabuddy", layout="wide")
 inject_css()
-
-# ---------- router setter that works across Streamlit versions ----------
-def go(route: str):
-    st.session_state["route"] = route
-    safe_rerun()
-
-# register go() for submodules
-set_go(go)
 
 # ---------- data & shared state ----------
 SYL = load_syllabus()


### PR DESCRIPTION
## Summary
- centralize navigation via new `get_go` helper and flexible `set_go`
- expose stable key generation and navigation pages across modules
- update all pages to retrieve `go` from session state

## Testing
- `python streamlit_app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c197d67ecc832b9827425e6f8ccd77