### PR TITLE
Fix go import by initializing navigation via set_go

### DIFF
--- a/fp/fp.py
+++ b/fp/fp.py
@@ -4,7 +4,7 @@ import random, re, pathlib
 from typing import Dict, List, Tuple, Optional
 
 import streamlit as st
-from common.ui import topbar, go
+from common.ui import topbar, get_go
 import streamlit.components.v1 as components
 
 # ---------- Try to attach your existing DnD component ----------
@@ -186,6 +186,7 @@ def _render_cloze(segs: List[str], answers: List[str], fills: List[Optional[str]
 # ---------- Public pages ----------
 def page_weakness_report():
     ensure_fp_state()
+    go = get_go()
     topbar("AI selection — enter weaknesses", back_to="select_subject_main")
     st.write("Enter weaknesses (semicolon-separated). The flow will cover **specific** then **general** for each weakness. "
              "If you add **specific** sub-weaknesses later, they run before returning to the general item.")
@@ -223,6 +224,7 @@ def page_weakness_report():
 
 def page_fp_flow():
     ensure_fp_state()
+    go = get_go()
     ss = st.session_state
 
     topbar("Focused Practice (Specific → General)", back_to="weakness_report")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -9,7 +9,15 @@ from typing import Dict, List, Tuple
 import streamlit as st
 
 # ---- Import shared UI + page modules ----
-from common.ui import go  # topbar, CSS, etc. are presumed in common/ui.py
+# ``go`` was previously imported directly from ``common.ui`` but that module now
+# exposes a ``set_go`` helper which initialises the navigation function and
+# stores it in ``st.session_state``.  Import and invoke ``set_go`` here to obtain
+# the default ``go`` implementation.
+from common.ui import set_go
+
+# Register the navigation function for use across modules and keep a local
+# reference for convenience.
+go = set_go()
 from homepage.homepage import page_home
 
 from selection.widgets import (


### PR DESCRIPTION
## Summary
- import and initialize navigation with `set_go` instead of missing `go`
- retrieve navigation function in FP page handlers with `get_go` to avoid ImportErrors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2613ea9d4832b8f86081f31b97778