### PR TITLE
Fix go import and register homepage routes

### DIFF
--- a/fp/fp.py
+++ b/fp/fp.py
@@ -4,7 +4,7 @@ import random, re, pathlib
 from typing import Dict, List, Tuple, Optional
 
 import streamlit as st
-from common.ui import topbar, go
+from common.ui import topbar, get_go
 import streamlit.components.v1 as components
 
 # ---------- Try to attach your existing DnD component ----------
@@ -186,6 +186,7 @@ def _render_cloze(segs: List[str], answers: List[str], fills: List[Optional[str]
 # ---------- Public pages ----------
 def page_weakness_report():
     ensure_fp_state()
+    go = get_go()
     topbar("AI selection — enter weaknesses", back_to="select_subject_main")
     st.write("Enter weaknesses (semicolon-separated). The flow will cover **specific** then **general** for each weakness. "
              "If you add **specific** sub-weaknesses later, they run before returning to the general item.")
@@ -223,6 +224,7 @@ def page_weakness_report():
 
 def page_fp_flow():
     ensure_fp_state()
+    go = get_go()
     ss = st.session_state
 
     topbar("Focused Practice (Specific → General)", back_to="weakness_report")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -10,10 +10,14 @@ import streamlit as st
 
 # ---- Import shared UI + page modules ----
 # ``go`` was previously imported directly from ``common.ui`` but that module now
-# exposes a ``set_go`` helper which seeds the navigation function into
-# ``st.session_state``.  Import it so we can initialise navigation lazily during
-# bootstrap.
+# exposes a ``set_go`` helper which initialises the navigation function and
+# stores it in ``st.session_state``.  Import and invoke ``set_go`` here to obtain
+# the default ``go`` implementation.
 from common.ui import set_go
+
+# Register the navigation function for use across modules and keep a local
+# reference for convenience.
+go = set_go()
 
 from homepage.homepage import page_home, page_select_subject_main
 from srs.srs import page_srs_menu
@@ -28,9 +32,6 @@ from ai.ai import page_ai_select, page_ai_review
 
 # FP engine (DnD integrated)
 from fp.fp import page_weakness_report, page_fp_flow, ensure_fp_state
-
-# Global navigation function placeholder populated during bootstrap
-go = None
 
 
 # ---------------- Page config ----------------

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -9,8 +9,14 @@ from typing import Dict, List, Tuple
 import streamlit as st
 
 # ---- Import shared UI + page modules ----
-from common.ui import go  # topbar, CSS, etc. are presumed in common/ui.py
-from homepage.homepage import page_home
+# ``go`` was previously imported directly from ``common.ui`` but that module now
+# exposes a ``set_go`` helper which seeds the navigation function into
+# ``st.session_state``.  Import it so we can initialise navigation lazily during
+# bootstrap.
+from common.ui import set_go
+
+from homepage.homepage import page_home, page_select_subject_main
+from srs.srs import page_srs_menu
 
 from selection.widgets import (
     page_cram_subjects, page_cram_modules, page_cram_iqs, page_cram_dotpoints,
@@ -22,6 +28,9 @@ from ai.ai import page_ai_select, page_ai_review
 
 # FP engine (DnD integrated)
 from fp.fp import page_weakness_report, page_fp_flow, ensure_fp_state
+
+# Global navigation function placeholder populated during bootstrap
+go = None
 
 
 # ---------------- Page config ----------------
@@ -94,6 +103,12 @@ def explode_syllabus(data: Dict) -> Tuple[
 
 # ---------------- Bootstrap shared state ----------------
 def ensure_core_state():
+    # Navigation handler
+    if "_go" not in st.session_state:
+        set_go()  # inject default go() into state
+    global go
+    go = st.session_state["_go"]
+
     # Route
     st.session_state.setdefault("route", "home")
 
@@ -103,7 +118,7 @@ def ensure_core_state():
     st.session_state.setdefault("focus_module", None)  # (s, m)
     st.session_state.setdefault("focus_iq", None)      # (s, m, iq)
 
-    # Some older pages may expect a callable in state; provide go for compatibility
+    # Some older pages may expect a callable in state; ensure it persists
     st.session_state.setdefault("_go", go)
 
     # Load syllabus once and fan out into fast-lookups used by selection pages
@@ -121,6 +136,8 @@ def ensure_core_state():
 ROUTES = {
     # Home
     "home": page_home,
+    "select_subject_main": page_select_subject_main,
+    "srs_menu": page_srs_menu,
 
     # Selection (CRAM)
     "cram_subjects": page_cram_subjects,


### PR DESCRIPTION
## Summary
- import and initialize navigation via `set_go` only when core state is set
- retrieve navigation function in FP page handlers with `get_go`
- register `srs_menu` and `select_subject_main` routes so homepage buttons work

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2613ea9d4832b8f86081f31b97778