### PR TITLE
Fix go import and register homepage routes

### DIFF
--- a/common/ui.py
+++ b/common/ui.py
@@ -43,8 +43,10 @@ def set_go(go=None):
     return go
 
 def get_go():
-    """Helper to retrieve the navigation function from session state."""
-    return st.session_state.get("_go")
+    """Return the navigation function, seeding a default if missing."""
+    if "_go" not in st.session_state:
+        return set_go()
+    return st.session_state["_go"]
 
 # ------------------------------
 # UI helpers

--- a/fp/fp.py
+++ b/fp/fp.py
@@ -4,7 +4,7 @@ import random, re, pathlib
 from typing import Dict, List, Tuple, Optional
 
 import streamlit as st
-from common.ui import topbar, go
+from common.ui import topbar, get_go
 import streamlit.components.v1 as components
 
 # ---------- Try to attach your existing DnD component ----------
@@ -186,6 +186,7 @@ def _render_cloze(segs: List[str], answers: List[str], fills: List[Optional[str]
 # ---------- Public pages ----------
 def page_weakness_report():
     ensure_fp_state()
+    go = get_go()
     topbar("AI selection — enter weaknesses", back_to="select_subject_main")
     st.write("Enter weaknesses (semicolon-separated). The flow will cover **specific** then **general** for each weakness. "
              "If you add **specific** sub-weaknesses later, they run before returning to the general item.")
@@ -223,6 +224,7 @@ def page_weakness_report():
 
 def page_fp_flow():
     ensure_fp_state()
+    go = get_go()
     ss = st.session_state
 
     topbar("Focused Practice (Specific → General)", back_to="weakness_report")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -9,8 +9,15 @@ from typing import Dict, List, Tuple
 import streamlit as st
 
 # ---- Import shared UI + page modules ----
-from common.ui import go  # topbar, CSS, etc. are presumed in common/ui.py
-from homepage.homepage import page_home
+# Navigation is provided via a ``go`` function stored in ``st.session_state``.
+# Use ``get_go`` to fetch (and lazily create) this function during bootstrap.
+from common.ui import get_go
+
+# Global reference for convenience; initialised in ``ensure_core_state``.
+go = None
+
+from homepage.homepage import page_home, page_select_subject_main
+from srs.srs import page_srs_menu
 
 from selection.widgets import (
     page_cram_subjects, page_cram_modules, page_cram_iqs, page_cram_dotpoints,
@@ -94,6 +101,10 @@ def explode_syllabus(data: Dict) -> Tuple[
 
 # ---------------- Bootstrap shared state ----------------
 def ensure_core_state():
+    # Navigation handler
+    global go
+    go = get_go()  # ensure ``_go`` exists and keep a local reference
+
     # Route
     st.session_state.setdefault("route", "home")
 
@@ -102,9 +113,6 @@ def ensure_core_state():
     st.session_state.setdefault("focus_subject", None)
     st.session_state.setdefault("focus_module", None)  # (s, m)
     st.session_state.setdefault("focus_iq", None)      # (s, m, iq)
-
-    # Some older pages may expect a callable in state; provide go for compatibility
-    st.session_state.setdefault("_go", go)
 
     # Load syllabus once and fan out into fast-lookups used by selection pages
     if "_SYL" not in st.session_state:
@@ -121,6 +129,8 @@ def ensure_core_state():
 ROUTES = {
     # Home
     "home": page_home,
+    "select_subject_main": page_select_subject_main,
+    "srs_menu": page_srs_menu,
 
     # Selection (CRAM)
     "cram_subjects": page_cram_subjects,


### PR DESCRIPTION
## Summary
- lazily seed navigation handler with `get_go` so `_go` always exists
- fetch navigation function during core state init instead of at import

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2613ea9d4832b8f86081f31b97778